### PR TITLE
Allow id to be returned in to_json

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,8 @@ class User < ActiveRecord::Base
 
   # Setup accessible (or protected) attributes for your model
   attr_accessible :email, :password, :password_confirmation, :remember_me
+
+  def self.blacklist_keys
+    @blacklist_keys ||= super - ["id"]
+  end
 end


### PR DESCRIPTION
Devise changes the serializable_hash so it does not include any attributes that are not accessible (https://github.com/plataformatec/devise/blob/master/lib/devise/models/serializable.rb). This commit puts id back in the user's serializable hash.
