### PR TITLE
 * fixed typo when calling for 'application' instead of '@application'

### DIFF
--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -19,5 +19,5 @@
   <h3>Actions</h3>
   <p><%= link_to 'List all', oauth_applications_path %></p>
   <p><%= link_to 'Edit', edit_oauth_application_path(@application) %></p>
-  <p><%= link_to 'Remove', [:oauth, application], :method => :delete, :confirm => "Are you sure?" %></p>
+  <p><%= link_to 'Remove', [:oauth, @application], :method => :delete, :confirm => "Are you sure?" %></p>
 </div>


### PR DESCRIPTION
A simple bug in the app which prevented the 'show' page for applications to work properly.  

application => @application
