### PR TITLE
update coffee-script-source from 1.1.3 to 1.8.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     coffee-script (2.2.0)
       coffee-script-source
       execjs
-    coffee-script-source (1.1.3)
+    coffee-script-source (1.8.0)
     devise (1.5.1)
       bcrypt-ruby (~> 3.0)
       orm_adapter (~> 0.0.3)


### PR DESCRIPTION
- fixes "Could not find coffee-script-source-1.1.3 in any of the
  sources"
