### PR TITLE
chore(deps): bump gems with open Dependabot alerts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
     ast (2.4.3)
     base64 (0.3.0)
-    bcrypt (3.1.20)
+    bcrypt (3.1.22)
     benchmark (0.5.0)
     bigdecimal (4.1.2)
     builder (3.3.0)
@@ -126,7 +126,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.19.8)
+    json (2.21.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.10.0)
@@ -147,16 +147,16 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.27.0)
-    net-imap (0.5.7)
+    net-imap (0.5.15)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.2)
+    net-protocol (0.3.0)
       timeout
     net-smtp (0.5.0)
       net-protocol
-    nio4r (2.7.4)
+    nio4r (2.7.5)
     nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -178,7 +178,7 @@ GEM
       method_source (~> 1.0)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
-    puma (7.1.0)
+    puma (7.2.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.7)
@@ -327,7 +327,8 @@ GEM
     useragent (0.16.11)
     warden (1.2.9)
       rack (>= 2.0.9)
-    websocket-driver (0.7.6)
+    websocket-driver (0.8.2)
+      base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     zeitwerk (2.8.3)


### PR DESCRIPTION
Lockfile-only update — resolves 17 of the 19 remaining open alerts (including all 5 high-severity ones).

| gem              | from     | to     |
| ---------------- | -------- | ------ |
| puma             | 7.1.0    | 7.2.1  |
| net-imap         | 0.5.7    | 0.5.15 |
| websocket-driver | 0.7.6    | 0.8.2  |
| erb              | 5.0.2    | 6.0.7  |
| bcrypt           | 3.1.20   | 3.1.22 |
| json             | 2.15.2.1 | 2.21.2 |

Dependabot was unable to create PRs for these (likely because `websocket-driver` 0.7.7+ added a `base64` dependency that falls outside its transitive update strategy). Verified locally with `rake db:setup spec` on Ruby 3.2.0.

The only 2 remaining alerts after this are `devise`, which needs `~> 4.9` → 5.x.

Follows #661 and #660.