### PR TITLE
Align Dockerfile bundler version with Gemfile.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:3.2.0
 LABEL maintainer="felipe@yerba.dev"
 
 RUN apt-get update && apt-get install -y nodejs --no-install-recommends
-RUN gem install bundler:2.2.21
+RUN gem install bundler:2.4.6
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
The Dockerfile pins bundler 2.2.21 while `Gemfile.lock` is generated with 2.4.6. The pinned version is never actually used — `ruby:3.2.0` ships bundler 2.4.1, which detects the mismatch, downloads bundler 2.4.6 mid-build and restarts itself.

Pinning 2.4.6 to match `BUNDLED WITH` removes the extra download and restart.

|                      | before | after |
| -------------------- | ------ | ----- |
| Fetching bundler     | 1      | 0     |
| bundler self-restart | 1      | 0     |
| gem metadata fetch   | 2      | 1     |

The resolved gem set is unchanged apart from bundler 2.4.6 no longer being installed as an extra gem.

Verified with `docker build --platform linux/amd64 --no-cache`.

Closes #317